### PR TITLE
update plexon offline sdk url

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,13 +16,13 @@
 
 using PLX, MAT, BinDeps, Base.Test
 
-# Unfortunately, these test files come from the SDK provided by Plexon Inc. and 
-# are assumed not to be redistributable 
+# Unfortunately, these test files come from the SDK provided by Plexon Inc. and
+# are assumed not to be redistributable
 testdir = joinpath(dirname(@__FILE__), "Matlab Offline Files SDK", "mexPlex", "tests")
 if !isdir(testdir)
 	parentdir = dirname(@__FILE__)
 	bundlezip = joinpath(parentdir, "Plexon Offline SDKs.zip")
-	run(download_cmd("http://www.plexon.com/sites/default/files/downloads/OmniPlex%20and%20MAP%20Offline%20SDK%20Bundle.zip",
+	run(download_cmd("http://www.plexon.com/sites/default/files/downloads/OmniPlex%20and%20MAP%20Offline%20SDK%20Bundle_0.zip",
 		             bundlezip))
 	cd(parentdir) do
 		run(`unzip $bundlezip`)


### PR DESCRIPTION
Tests were failing due to a 404 from the old bundle url... updated, tests are now passing.